### PR TITLE
Quantum gates sympy numeric types fix

### DIFF
--- a/discopy/quantum/gates.py
+++ b/discopy/quantum/gates.py
@@ -249,7 +249,7 @@ class Rx(Rotation):
 
     @property
     def array(self):
-        half_theta = np.pi * self.phase
+        half_theta = float(np.pi * self.phase)
         sin, cos = np.sin(half_theta), np.cos(half_theta)
         return np.array([[cos, -1j * sin], [-1j * sin, cos]])
 
@@ -261,7 +261,7 @@ class Rz(Rotation):
 
     @property
     def array(self):
-        half_theta = np.pi * self.phase
+        half_theta = float(np.pi * self.phase)
         return np.array(
             [[np.exp(-1j * half_theta), 0], [0, np.exp(1j * half_theta)]])
 
@@ -273,7 +273,7 @@ class CU1(Rotation):
 
     @property
     def array(self):
-        theta = 2 * np.pi * self.phase
+        theta = float(2 * np.pi * self.phase)
         return np.array([1, 0, 0, 0,
                          0, 1, 0, 0,
                          0, 0, 1, 0,
@@ -287,7 +287,7 @@ class CRz(Rotation):
 
     @property
     def array(self):
-        half_theta = np.pi * self.phase
+        half_theta = float(np.pi * self.phase)
         return np.array([1, 0, 0, 0,
                          0, 1, 0, 0,
                          0, 0, np.exp(-1j * half_theta), 0,
@@ -301,7 +301,7 @@ class CRx(Rotation):
 
     @property
     def array(self):
-        half_theta = np.pi * self.phase
+        half_theta = float(np.pi * self.phase)
         cos, sin = np.cos(half_theta), np.sin(half_theta)
         return np.array([1, 0, 0, 0,
                          0, 1, 0, 0,


### PR DESCRIPTION
Please review my code fixing a problem in the quantum submodule. When a substitution with `subs` is performed on a parametric circuit, eval fails by reporting an error of the form `loop of ufunc does not support argument 0 of type Zero which has no callable exp method`. This is due to a sympy numeric type being evaluated by numpy. The same error is replicated by the simple statement below:
```python
import sympy as sy
import numpy as np
np.exp(sy.sympify(0))
```
In the solution I force the casting of the variables `half_theta` of the rotation gates to float (being angles they are expected real) so that the numpy primitives are able to interpret them. 