### PR TITLE
Fix circuit subs ob factory

### DIFF
--- a/discopy/quantum/circuit.py
+++ b/discopy/quantum/circuit.py
@@ -38,7 +38,6 @@ from itertools import takewhile
 from collections.abc import Mapping
 
 from discopy import messages, monoidal, rigid, tensor
-from discopy.monoidal import Functor
 from discopy.cat import AxiomError
 from discopy.rigid import Ob, Ty, Diagram
 from discopy.tensor import np, Dim, Tensor
@@ -116,8 +115,7 @@ class Circuit(tensor.Diagram):
 
     def subs(self, *args):
         return self.upgrade(
-            Functor(ob=lambda x: x, ar=lambda f: f.subs(*args),
-                    ob_factory=BitsAndQubits)(self))
+            CircuitFunctor(ob=lambda x: x, ar=lambda f: f.subs(*args))(self))
 
     @property
     def is_mixed(self):

--- a/discopy/quantum/circuit.py
+++ b/discopy/quantum/circuit.py
@@ -38,6 +38,7 @@ from itertools import takewhile
 from collections.abc import Mapping
 
 from discopy import messages, monoidal, rigid, tensor
+from discopy.monoidal import Functor
 from discopy.cat import AxiomError
 from discopy.rigid import Ob, Ty, Diagram
 from discopy.tensor import np, Dim, Tensor
@@ -112,6 +113,11 @@ class Circuit(tensor.Diagram):
     """ Classical-quantum circuits. """
     def __repr__(self):
         return super().__repr__().replace('Diagram', 'Circuit')
+
+    def subs(self, *args):
+        return self.upgrade(
+            Functor(ob=lambda x: x, ar=lambda f: f.subs(*args),
+                    ob_factory=BitsAndQubits)(self))
 
     @property
     def is_mixed(self):

--- a/test/test_quantum.py
+++ b/test/test_quantum.py
@@ -275,6 +275,10 @@ def test_subs():
     circuit = sqrt(2) @ Ket(0, 0) >> H @ Rx(phi) >> CX >> Bra(0, 1)
     assert circuit.subs(phi, 0.5)\
         == sqrt(2) @ Ket(0, 0) >> H @ Rx(0.5) >> CX >> Bra(0, 1)
+    
+    assert (Id(1) @ scalar(phi)).subs(phi, 1).dom == qubit
+    # Once 'scalar' is supported by circuit2zx, test also
+    # circuit2zx((Id(1) @ scalar(phi)).subs(phi, 1))
 
 
 def test_grad():


### PR DESCRIPTION
Please review my pull request fixing the following glitch. In this code snippet
```python
(Id(1) @ scalar(theta)).subs(theta, 1/2).dom
```
the invocation of `subs` makes `dom` (and `cod`) loose the type `BitsAndQubits`. The returned value is `Ty('quit')` which then causes problems with the functor `circuit2zx`. In my proposal I'm re-implementing the `quantum.circuit.Circuit.subs` with `CircuitFunctor` which has the proper `ob_factory`. The implementation also contains a test for checking the condition. 
Thanks
