### PR TITLE
Small fix and performance tweaks.

### DIFF
--- a/discopy/rigid.py
+++ b/discopy/rigid.py
@@ -213,7 +213,7 @@ class Diagram(monoidal.Diagram):
     @staticmethod
     def ba(left, right):
         """ Backward application. """
-        off = -len(left) or len(right)
+        off = len(left) or -len(right)
         return Diagram.cups(left, right[:off]) @ Id(right[off:])
 
     @staticmethod


### PR DESCRIPTION
1. Fix rigid backward application.

2. Make some performance tweaks to monoidal:
    - Use `Ty._objects` instead of derived iterators when possible.
    - Improve argument handling in `Diagram.tensor`.

