### PR TITLE
Fix `tensor.Id` constructor default argument, from `Ty()` to `Dim()`.

### DIFF
--- a/discopy/tensor.py
+++ b/discopy/tensor.py
@@ -13,9 +13,8 @@ Implements dagger monoidal functors into tensors.
 
 import numpy
 
-from discopy import messages, monoidal, rigid, config
+from discopy import cat, config, messages, monoidal, rigid
 from discopy.cat import AxiomError
-from discopy.monoidal import Sum
 from discopy.rigid import Ob, Ty, Cup, Cap
 
 
@@ -552,6 +551,9 @@ class Diagram(rigid.Diagram):
 
 class Id(rigid.Id, Diagram):
     """ Identity tensor.Diagram """
+    def __init__(self, dom=Dim()):
+        rigid.Id.__init__(self, dom)
+        Diagram.__init__(self, dom, dom, [], [], layers=cat.Id(dom))
 
 
 class Sum(monoidal.Sum, Diagram):

--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -104,13 +104,15 @@ def test_Functor_call():
     assert list(F(g.transpose(left=True)).array.flatten()) == [0.0, 1.0, 2.0]
     with raises(TypeError):
         F("Alice")
+    assert Functor(ob={x: Ty(2, 3)}, ar=None)(x) == Dim(2, 3)
 
 
 def test_Functor_swap():
     x, y = Ty('x'), Ty('y')
     f, g = rigid.Box('f', x, x), rigid.Box('g', y, y)
     F = Functor({x: 2, y: 3}, {f: [1, 2, 3, 4], g: list(range(9))})
-    assert F(f @ g >> Diagram.swap(x, y)) == F(Diagram.swap(x, y) >> g @ f)
+    assert F(f @ g >> rigid.Diagram.swap(x, y)) == \
+           F(rigid.Diagram.swap(x, y) >> g @ f)
 
 
 def test_AxiomError():
@@ -151,6 +153,12 @@ def test_Diagram_cups_and_caps():
     assert Id(Dim(2)).transpose()\
         == Spider(0, 2, dim=2) @ Id(Dim(2))\
         >> Id(Dim(2)) @ Spider(2, 0, dim=2)
+
+
+def test_Diagram_swap():
+    x, y, z = Dim(2), Dim(3), Dim(4)
+    assert Diagram.swap(x, y @ z) == \
+           (Swap(x, y) @ Id(z)) >> (Id(y) @ Swap(x, z))
 
 
 def test_Box():


### PR DESCRIPTION
Also fix affected tests.