### PR TITLE
Feature/diagram data

### DIFF
--- a/discopy/cartesian.py
+++ b/discopy/cartesian.py
@@ -143,8 +143,8 @@ class Function(rigid.Box):
         dom, cod = self.dom @ other.dom, self.cod @ other.cod
 
         def product(*vals):
-            vals0 = tuplify(self(*vals[:len(self.dom)]))
-            vals1 = tuplify(other(*vals[len(self.dom):]))
+            vals0 = tuplify(self.function(*vals[:len(self.dom)]))
+            vals1 = tuplify(other.function(*vals[len(self.dom):]))
             return untuplify(*(vals0 + vals1))
         return Function(dom, cod, product)
 

--- a/discopy/cartesian.py
+++ b/discopy/cartesian.py
@@ -123,8 +123,8 @@ class Function(rigid.Box):
             raise TypeError(messages.type_err(Function, other))
         if len(self.cod) != len(other.dom):
             raise AxiomError(messages.does_not_compose(self, other))
-        return Function(self.dom, other.cod,
-                        lambda *vals: other(*tuplify(self(*vals))))
+        function = lambda *vals: other.function(*tuplify(self.function(*vals)))
+        return Function(self.dom, other.cod, function)
 
     def tensor(self, *others):
         """

--- a/discopy/cartesian.py
+++ b/discopy/cartesian.py
@@ -34,6 +34,8 @@ We can check the axioms for the Copy/Discard comonoid on specific inputs:
 >>> assert (Copy(4) >> Swap(4, 4))(42, 43, 44, 45) == Copy(4)(42, 43, 44, 45)
 """
 
+from compose import compose
+
 from discopy.cat import AxiomError
 from discopy import messages, monoidal, rigid
 from discopy.monoidal import Sum
@@ -123,7 +125,8 @@ class Function(rigid.Box):
             raise TypeError(messages.type_err(Function, other))
         if len(self.cod) != len(other.dom):
             raise AxiomError(messages.does_not_compose(self, other))
-        function = lambda *vals: other.function(*tuplify(self.function(*vals)))
+        function = compose(lambda vals: other.function(*vals), tuplify,
+                           self.function)
         return Function(self.dom, other.cod, function)
 
     def tensor(self, *others):

--- a/setup.py
+++ b/setup.py
@@ -39,5 +39,5 @@ if __name__ == '__main__':  # pragma: no cover
           tests_require=TEST_REQ,
           extras_require={'test': TEST_REQ},
           data_file=[('test', ['test/requirements.txt'])],
-          python_requires='>=3',
+          python_requires='>=3.7',
           )


### PR DESCRIPTION
Hello to Alexis and other Discopy maintainers,

This pull request adds a small, but actually surprisingly useful feature.  In multiple applications now I've found that I have a need to not only read out the data attached to an individual morphism, but to consider the data attached to an entire diagram in a structured way.  When it hit me what I was doing, I abstracted out the pattern.  The classes in this pull request give a structured way (as an F-algebra) to represent and return the arbitrary data attached to a diagram, alongside a catamorphism on that structure.

Please just say so if this doesn't suit your vision for Discopy and I can include it only in my/our custom fork at Northeastern.  If you have modifications or additions you'd like before merging, please also let me know.

Thank you for your work,
Eli