### PR TITLE
Fix tensor array

### DIFF
--- a/discopy/tensor.py
+++ b/discopy/tensor.py
@@ -644,7 +644,11 @@ class Box(rigid.Box, Diagram):
     def array(self):
         """ The array inside the box. """
         dom, cod = self.dom, self.cod
-        return Tensor.np.array(self.data).reshape(tuple(dom @ cod) or (1, ))
+        data = self.data
+        try:
+            return Tensor.np.array(data).reshape(tuple(dom @ cod) or (1, ))
+        except ValueError:
+            return data
 
     def grad(self, var, **params):
         return self.bubble(

--- a/discopy/tensor.py
+++ b/discopy/tensor.py
@@ -661,7 +661,7 @@ class Box(rigid.Box, Diagram):
     def __eq__(self, other):
         if not isinstance(other, Box):
             return False
-        return Tensor.np.all(self.array == other.array)\
+        return Tensor.np.all(Tensor.np.array(self.array == other.array))\
             and (self.name, self.dom, self.cod)\
             == (other.name, other.dom, other.cod)
 

--- a/discopy/tensor.py
+++ b/discopy/tensor.py
@@ -169,9 +169,9 @@ class Tensor(rigid.Box):
 
     def __eq__(self, other):
         if not isinstance(other, Tensor):
-            return Tensor.np.all(self.array == other)
+            return Tensor.np.all(Tensor.np.array(self.array == other))
         return (self.dom, self.cod) == (other.dom, other.cod)\
-            and Tensor.np.all(self.array == other.array)
+            and Tensor.np.all(Tensor.np.array(self.array == other.array))
 
     def then(self, *others):
         if len(others) != 1 or any(isinstance(other, Sum) for other in others):

--- a/discopy/tensor.py
+++ b/discopy/tensor.py
@@ -647,7 +647,7 @@ class Box(rigid.Box, Diagram):
         data = self.data
         try:
             return Tensor.np.array(data).reshape(tuple(dom @ cod) or (1, ))
-        except ValueError:
+        except Exception:
             return data
 
     def grad(self, var, **params):

--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -256,3 +256,8 @@ def test_non_numpy_eval():
     with raises(Exception):
         Swap(Dim(2), Dim(2)).eval()
     Tensor.np = np
+
+
+def test_Tensor_array():
+    box = Box("box", Dim(2), Dim(2), None)
+    assert box.array is None


### PR DESCRIPTION
Fixes this error:
```python
from discopy.tensor import Box, Dim
from sympy import symbols

sym = symbols('x')
box = Box('box', Dim(1), Dim(2), sym)
box == box
```

```
line 604, in array
    return Tensor.np.array(self.data).reshape(tuple(dom @ cod) or (1, ))
ValueError: cannot reshape array of size 1 into shape (2,)
```
`Tensor.box`s can be symbolic or `None`, so that a value can be substituted later. Before it is substituted, accessing the `.array` property will cause an error as a `Symbol` or `None` cannot be reshaped.

