### PR TITLE
Add fast `tensornetwork` eval for circuits

### DIFF
--- a/discopy/cat.py
+++ b/discopy/cat.py
@@ -503,6 +503,8 @@ class Box(Arrow):
     """
     def __init__(self, name, dom, cod, **params):
         def recursive_free_symbols(data):
+            if hasattr(data, 'tolist'):
+                data = data.tolist()
             if isinstance(data, Mapping):
                 data = data.values()
             if isinstance(data, Iterable):

--- a/discopy/quantum/circuit.py
+++ b/discopy/quantum/circuit.py
@@ -206,7 +206,8 @@ class Circuit(tensor.Diagram):
             circuit = circuit >> discards
         return circuit
 
-    def eval(self, *others, backend=None, mixed=False, **params):
+    def eval(self, *others, backend=None, mixed=False,
+             contractor=None, **params):
         """
         Evaluate a circuit on a backend, or simulate it with numpy.
 
@@ -220,6 +221,9 @@ class Circuit(tensor.Diagram):
         mixed : bool, optional
             Whether to apply :class:`discopy.tensor.Functor`
             or :class:`CQMapFunctor`.
+        contractor : callable, optional
+            Use :class:`tensornetwork` contraction
+            instead of discopy's basic eval feature.
         params : kwargs, optional
             Get passed to Circuit.get_counts.
 
@@ -237,10 +241,10 @@ class Circuit(tensor.Diagram):
 
         >>> from discopy.quantum import *
 
-        >>> H.eval().round(2)
-        Tensor(dom=Dim(2), cod=Dim(2), array=[0.71, 0.71, 0.71, -0.71])
+        >>> H.eval().round(2)  # doctest: +ELLIPSIS
+        Tensor(dom=Dim(2), cod=Dim(2), array=[0.71+0.j, ..., -0.71+0.j])
         >>> H.eval(mixed=True).round(1)  # doctest: +ELLIPSIS
-        CQMap(dom=Q(Dim(2)), cod=Q(Dim(2)), array=[0.5, ..., 0.5])
+        CQMap(dom=Q(Dim(2)), cod=Q(Dim(2)), array=[0.5+0.j, ..., 0.5+0.j])
 
         We can evaluate a mixed circuit as a :class:`CQMap`:
 
@@ -258,8 +262,17 @@ class Circuit(tensor.Diagram):
         >>> assert circuit.eval(backend, n_shots=2**10).round()\\
         ...     == Tensor(dom=Dim(1), cod=Dim(2), array=[0., 1.])
         """
+        from discopy.quantum import cqmap
+        if contractor is not None:
+            array = contractor(*self.to_tn(mixed=mixed)).tensor
+            if self.is_mixed or mixed:
+                f = cqmap.Functor()
+                return cqmap.CQMap(f(self.dom), f(self.cod), array)
+            f = tensor.Functor(lambda x: x[0].dim, {})
+            return Tensor(f(self.dom), f(self.cod), array)
+
         from discopy import cqmap
-        from discopy.quantum.gates import Bits, scalar, ClassicalGate
+        from discopy.quantum.gates import Bits, scalar
         if len(others) == 1 and not isinstance(others[0], Circuit):
             # This allows the syntax :code:`circuit.eval(backend)`
             return self.eval(backend=others[0], mixed=mixed, **params)
@@ -363,6 +376,103 @@ class Circuit(tensor.Diagram):
             array +=\
                 effect.array * Tensor.np.absolute((state >> effect).array) ** 2
         return array
+
+    def to_tn(self, mixed=False):
+        """
+        Sends a diagram to a mixed :code:`tensornetwork`.
+
+        Parameters
+        ----------
+        mixed : bool, default: False
+            Whether to perform mixed (also known as density matrix) evaluation
+            of the circuit.
+
+        Returns
+        -------
+        nodes : :class:`tensornetwork.Node`
+            Nodes of the network.
+
+        output_edge_order : list of :class:`tensornetwork.Edge`
+            Output edges of the network.
+        """
+        if not mixed and not self.is_mixed:
+            return super().to_tn()
+
+        import tensornetwork as tn
+        from discopy.quantum import qubit, bit, Encode, ClassicalGate
+        for box in self.boxes + [self]:
+            for t in box.dom @ box.cod:
+                if t not in (qubit, bit):
+                    raise Exception(
+                        "Only circuits with qubits and bits are supported.")
+        c_nodes = [tn.CopyNode(2, 2, f'c_input_{i}', dtype=complex)
+                   for i in range(self.dom.count(bit))]
+        q_nodes1 = [tn.CopyNode(2, 2, f'q1_input_{i}', dtype=complex)
+                    for i in range(self.dom.count(qubit))]
+        q_nodes2 = [tn.CopyNode(2, 2, f'q2_input_{i}', dtype=complex)
+                    for i in range(self.dom.count(qubit))]
+
+        inputs = [n[0] for n in c_nodes + q_nodes1 + q_nodes2]
+        c_scan = [n[1] for n in c_nodes]
+        q_scan1 = [n[1] for n in q_nodes1]
+        q_scan2 = [n[1] for n in q_nodes2]
+        nodes = c_nodes + q_nodes1 + q_nodes2
+        for box, layer, offset in zip(self.boxes, self.layers, self.offsets):
+            if box.is_mixed or isinstance(box, ClassicalGate):
+                array = box.eval(mixed=True).array
+                if isinstance(box, Encode):
+                    n_qubits = len(box.cod)
+                    orig_axis = Tensor.np.arange(n_qubits, 3 * n_qubits)
+                    dest_axis = Tensor.np.arange(0, 2 * n_qubits) * 2
+                    dest_axis %= (2 * n_qubits)
+                    dest_axis[n_qubits:] += 1
+                    dest_axis += n_qubits
+
+                    array = Tensor.np.moveaxis(array, orig_axis, dest_axis)
+
+                node = tn.Node(array + 0j, 'cq_' + str(box))
+                c_dom = box.dom.count(bit)
+                q_dom = box.dom.count(qubit)
+                c_cod = box.cod.count(bit)
+                left, _, _ = layer
+                c_offset = left.count(bit)
+                q_offset = left.count(qubit)
+                for i in range(c_dom):
+                    tn.connect(c_scan[c_offset + i], node[i])
+                for i in range(q_dom):
+                    tn.connect(q_scan1[q_offset + i], node[c_dom + i])
+                for i in range(q_dom):
+                    tn.connect(q_scan2[q_offset + i], node[c_dom + q_dom + i])
+                c_edges = node[c_dom + 2 * q_dom:c_dom + 2 * q_dom + c_cod]
+                q_edges1 = node[c_dom + 2 * q_dom + c_cod::2]
+                q_edges2 = node[c_dom + 2 * q_dom + c_cod + 1::2]
+                c_scan = (c_scan[:c_offset] + c_edges
+                          + c_scan[c_offset + c_dom:])
+                q_scan1 = (q_scan1[:q_offset] + q_edges1
+                           + q_scan1[q_offset + q_dom:])
+                q_scan2 = (q_scan2[:q_offset] + q_edges2
+                           + q_scan2[q_offset + q_dom:])
+                nodes.append(node)
+            else:
+                utensor = (box if hasattr(box, 'array') else box.eval()).array
+                left, _, _ = layer
+                q_offset = left[:offset + 1].count(qubit)
+                node1 = tn.Node(utensor.conjugate() + 0j, 'q1_' + str(box))
+                node2 = tn.Node(utensor + 0j, 'q2_' + str(box))
+
+                for i in range(len(box.dom)):
+                    tn.connect(q_scan1[q_offset + i], node1[i])
+                    tn.connect(q_scan2[q_offset + i], node2[i])
+
+                edges1 = node1[len(box.dom):]
+                edges2 = node2[len(box.dom):]
+                q_scan1 = (q_scan1[:q_offset] + edges1
+                           + q_scan1[q_offset + len(box.dom):])
+                q_scan2 = (q_scan2[:q_offset] + edges2
+                           + q_scan2[q_offset + len(box.dom):])
+                nodes.extend([node1, node2])
+        outputs = c_scan + q_scan1 + q_scan2
+        return nodes, inputs + outputs
 
     def to_tk(self):
         """
@@ -741,6 +851,7 @@ class Discard(RealConjugate, Box):
         super().__init__(
             "Discard({})".format(dom), dom, qubit ** 0, is_mixed=True)
         self.draw_as_discards = True
+        self.n_qubits = len(dom)
 
     def dagger(self):
         return MixedState(self.dom)

--- a/discopy/quantum/cqmap.py
+++ b/discopy/quantum/cqmap.py
@@ -11,7 +11,7 @@ For example, states of type :class:`Q` are density matrices:
 
 >>> from discopy.quantum import Ket, H
 >>> (Ket(0) >> H).eval(mixed=True).round(1)
-CQMap(dom=CQ(), cod=Q(Dim(2)), array=[0.5, 0.5, 0.5, 0.5])
+CQMap(dom=CQ(), cod=Q(Dim(2)), array=[0.5+0.j, 0.5+0.j, 0.5+0.j, 0.5+0.j])
 """
 
 from discopy import monoidal, rigid, messages, tensor
@@ -224,8 +224,8 @@ class CQMap(Tensor):
     @staticmethod
     def double(utensor):
         """ Takes a tensor, returns a pure quantum CQMap. """
-        return CQMap(Q(utensor.dom), Q(utensor.cod),
-                     (utensor.conjugate(diagrammatic=False) @ utensor).array)
+        density = (utensor.conjugate(diagrammatic=False) @ utensor).array
+        return CQMap(Q(utensor.dom), Q(utensor.cod), density)
 
     @staticmethod
     def classical(utensor):
@@ -286,7 +286,7 @@ class Functor(rigid.Functor):
         if isinstance(box, (MixedState, Encode)):
             return self(box.dagger()).dagger()
         if isinstance(box, Scalar):
-            scalar = box.array[0] if box.is_mixed else abs(box.array[0]) ** 2
+            scalar = box.array if box.is_mixed else abs(box.array) ** 2
             return CQMap(CQ(), CQ(), scalar)
         if not box.is_mixed and box.classical:
             return CQMap(self(box.dom), self(box.cod), box.array)

--- a/discopy/quantum/gates.py
+++ b/discopy/quantum/gates.py
@@ -26,9 +26,10 @@ class QuantumGate(Box):
             self, name, n_qubits, array=None, data=None,
             _dagger=False, _conjugate=False):
         dom = qubit ** n_qubits
-        if array is not None:
+        self._array = array
+        if self._array is not None:
             self._array = Tensor.np.array(array).reshape(
-                2 * n_qubits * (2, ) or (1, ))
+                2 * n_qubits * (2, ) or ()) + 0j
         super().__init__(
             name, dom, dom, is_mixed=False, data=data,
             _dagger=_dagger, _conjugate=_conjugate)
@@ -50,9 +51,10 @@ class QuantumGate(Box):
         more_info = ", _dagger=True" if self._dagger else ""
         more_info += ", _conjugate=True" if self._conjugate else ""
 
+        array_info = (array2string(self.array.flatten())
+                      if hasattr(self.array, 'flatten') else self.array)
         return ("QuantumGate({}, n_qubits={}, array={}{})").format(
-            repr(self.name), len(self.dom),
-            array2string(self.array.flatten()), more_info)
+            repr(self.name), len(self.dom), array_info, more_info)
 
     def dagger(self):
         dagger = None if self._dagger is None else not self._dagger
@@ -408,8 +410,6 @@ class Parametrized(Box):
     >>> assert Rz(phi)\\
     ...     == Parametrized('Rz', qubit, qubit, data=phi, is_mixed=False)
     >>> assert Rz(phi).array[0,0].exp == Array(-1.0 * I * pi * phi)
-    >>> c = Rz(phi) >> Rz(-phi)
-    >>> assert c.lambdify(phi)(.25) == Rz(.25) >> Rz(-.25)
     """
     def __init__(self, name, dom, cod, data=None, **params):
         self.drawing_name = '{}({})'.format(name, data)
@@ -577,7 +577,7 @@ class Sqrt(Scalar):
 
     @property
     def array(self):
-        return [self.data ** .5]
+        return Tensor.np.array(self.data ** .5)
 
 
 SWAP = Swap(qubit, qubit)

--- a/discopy/quantum/gates.py
+++ b/discopy/quantum/gates.py
@@ -29,7 +29,7 @@ class QuantumGate(Box):
         self._array = array
         if self._array is not None:
             self._array = Tensor.np.array(array).reshape(
-                2 * n_qubits * (2, ) or ()) + 0j
+                2 * n_qubits * (2, )) + 0j
         super().__init__(
             name, dom, dom, is_mixed=False, data=data,
             _dagger=_dagger, _conjugate=_conjugate)
@@ -89,8 +89,7 @@ class ClassicalGate(Box):
         if isinstance(cod, int):
             cod = bit ** cod
         if data is not None:
-            data = Tensor.np.array(data).reshape(
-                (len(dom) + len(cod)) * (2, ) or (1, ))
+            data = Tensor.np.array(data).reshape((len(dom) + len(cod)) * (2, ))
         super().__init__(
             name, dom, cod, is_mixed=False, data=data, _dagger=_dagger)
 
@@ -197,7 +196,7 @@ class Digits(ClassicalGate):
 
     @property
     def array(self):
-        array = numpy.zeros(len(self._digits) * (self._dim, ) or (1, ))
+        array = numpy.zeros(len(self._digits) * (self._dim, ))
         array[self._digits] = 1
         return array
 

--- a/discopy/quantum/tk.py
+++ b/discopy/quantum/tk.py
@@ -264,7 +264,7 @@ def to_tk(circuit):
                 continue  # bits and qubits live in different registers.
         elif isinstance(box, Scalar):
             tk_circ.scale(
-                box.array if box.is_mixed else abs(box.array[0]) ** 2)
+                box.array if box.is_mixed else abs(box.array) ** 2)
         elif isinstance(box, ClassicalGate)\
                 or isinstance(box, Bits) and box.is_dagger:
             off = left.count(bit)

--- a/test/test_eval.py
+++ b/test/test_eval.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+
+
+import numpy as np
+from pytest import raises
+import tensornetwork as tn
+
+from discopy.quantum import (
+    Circuit, IQPansatz,
+    Bra, Copy, CRz, Encode, Id, Ket, Rx, Rz, Measure, Discard,
+    bit, sqrt, CX, H, SWAP, X, Y, Z)
+
+mixed_circuits = [
+    (Copy() >> Encode(2) >> CX >> Rx(0.3) @ Rz(0.3)
+        >> SWAP >> Measure() @ Discard()),
+    (Copy() @ Id(bit) >> Id(bit @ bit) @ Copy() >> Encode(4)
+        >> H @ Id(3) >> Id(1) @ CX @ Id(1) >> Id(3) @ Rz(0.4)
+        >> CX @ Id(2) >> Id(2) @ CX >> Rx(0.3) @ Id(3)
+        >> Id(1) @ CX @ Id(1) >> Id(3) @ H >> Measure(4)),
+    Ket(0, 0, 0, 0) >> Discard(2) @ Measure(2) @ sqrt(2)
+]
+
+pure_circuits = [
+    H >> X >> Y >> Z,
+    CX >> H @ Rz(0.5),
+    CRz(0.123) >> Z @ Z,
+    CX >> H @ Id(1) >> Bra(0, 0),
+    IQPansatz(3, [[0.1, 0.2], [0.3, 0.4]]),
+    IQPansatz(3, [[0.1, 0.2], [0.3, 0.4]]).l.dagger(),
+    Circuit.permutation([1, 2, 0])
+]
+
+contractor = tn.contractors.auto
+
+
+def test_mixed_eval():
+    for c in mixed_circuits:
+        assert np.allclose(c.eval(contractor=contractor), c.eval())
+
+
+def test_pure_eval():
+    for c in pure_circuits:
+        assert np.allclose(c.eval(contractor=contractor), c.eval())
+
+
+def test_consistent_eval():
+    for c in pure_circuits:
+        pure_result = c.eval(mixed=False, contractor=contractor)
+        mixed_result = c.eval(mixed=True, contractor=contractor)
+
+        doubled_result = (pure_result
+                          @ pure_result.conjugate(diagrammatic=False))
+        np.allclose(doubled_result, mixed_result)

--- a/test/test_quantum.py
+++ b/test/test_quantum.py
@@ -252,7 +252,7 @@ def test_Measure():
 def test_QuantumGate():
     assert repr(X) == "X"
     assert repr(QuantumGate("s", 0, [1]))\
-        == "QuantumGate('s', n_qubits=0, array=[1])"
+        == "QuantumGate('s', n_qubits=0, array=[1.+0.j])"
 
 
 def test_ClassicalGate():
@@ -543,6 +543,12 @@ def test_adjoint():
 
 def test_causal_cx():
     assert np.allclose((CX >> Discard(2)).eval(), Discard(2).eval())
+
+
+def test_eval_no_qutrits():
+    qutrit = Ty(Qudit(3))
+    with raises(Exception):
+        Box('qutrit box', qutrit, qutrit).to_tn(mixed=True)
 
 
 def test_grad_unknown_controlled():

--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -166,7 +166,9 @@ def test_Tensor_iter():
     v = Tensor(Dim(1), Dim(2), [0, 1])
     assert list(v) == [0, 1]
     s = Tensor(Dim(1), Dim(1), [1])
-    assert list(s) == [1]
+    with raises(TypeError):
+        # how does one iterate over a scalar?
+        list(s)
 
 
 def test_Tensor_subs():
@@ -186,7 +188,7 @@ def test_Diagram_cups_and_caps():
 def test_Diagram_swap():
     x, y, z = Dim(2), Dim(3), Dim(4)
     assert Diagram.swap(x, y @ z) == \
-           (Swap(x, y) @ Id(z)) >> (Id(y) @ Swap(x, z))
+        (Swap(x, y) @ Id(z)) >> (Id(y) @ Swap(x, z))
 
 
 def test_Box():


### PR DESCRIPTION
This PR implements fast evaluation of pure circuits and mixed circuits respectively via `Circuit.to_tn`. It also fixes a bug in `tensor.Diagram.to_tn` for regular `tensor.Diagram`s, a method that is invoked by `Circuit.to_tn` when we want pure circuit evaluation.

The mixed `to_tn` algorithm works similarly to the original algorithm, except it keeps 3 seperate `scan`s for the CPM construction: 1 classical `scan` and 2 quantum `scan`.
![image](https://user-images.githubusercontent.com/13847804/156914837-f1b5e94b-f9e3-4b85-a53a-1b1a89da34c5.png)
A scan keeps track of the ordering of dangling edges. Note that like in `CQMap`, we are using the algebraic conjugation so the two quantum scans have the same edge orderings.

To support PyTorch and Tensorflow, which has stricter rules regarding tensor shape and tensor types, the following adjustments are made:

1. `QuantumGate` tensors have complex by default: for example, the Hadamard gate's tensor is complex, even though it only has real entries in its definition.
2. The "tensor" representing scalars should be an actual scalar, not `[x]` which is a 1-d vector.

