### PR TITLE
Fix `.subs()`

### DIFF
--- a/discopy/utils.py
+++ b/discopy/utils.py
@@ -82,7 +82,11 @@ def rmap(func, data):
 
 def rsubs(data, *args):
     """ Substitute recursively along nested data. """
-    return rmap(lambda x: getattr(x, "subs", lambda *_: x)(*args), data)
+    from sympy import lambdify
+    if isinstance(args, Iterable) and not isinstance(args[0], Iterable):
+        args = (args, )
+    keys, values = zip(*args)
+    return rmap(lambda x: lambdify(keys, x)(*values), data)
 
 
 def load_corpus(url):


### PR DESCRIPTION
Closes #45.

Seems like `sympy.subs()` is only good for substituting from symbolic expression to symbolic expression, and the only way to robustly convert concrete `sympy.core.Expr` to a python number is using `sympy.lambdify`.

This PR reimplements `rsubs` to use `sympy.lambdify` internally. This doesn't affect the `subs` interface of `discopy`.