### PR TITLE
VS Code dark mode background colour fix

### DIFF
--- a/discopy/drawing.py
+++ b/discopy/drawing.py
@@ -439,7 +439,7 @@ class TikzBackend(Backend):
 class MatBackend(Backend):
     """ Matplotlib drawing backend. """
     def __init__(self, axis=None, figsize=None):
-        self.axis = axis or plt.subplots(figsize=figsize)[1]
+        self.axis = axis or plt.subplots(figsize=figsize, facecolor='white')[1]
         super().__init__()
 
     def draw_text(self, text, i, j, **params):


### PR DESCRIPTION
The background would change to transparent when drawing diagrams with `Spiders`, which did not look nice when using a dark mode editor. This PR fixes the issue.
Then:
<img width="579" alt="Screenshot 2022-05-05 at 16 16 09" src="https://user-images.githubusercontent.com/37929273/166957147-119cf9e7-bd2c-4ef6-806b-10dea2f7cdf5.png">
Now:
<img width="579" alt="Screenshot 2022-05-05 at 16 16 32" src="https://user-images.githubusercontent.com/37929273/166957157-0fd270bf-7666-4bc8-962c-3bcbb3221bcf.png">