### PR TITLE
Pennylane conversion for discopy circuits

### DIFF
--- a/discopy/quantum/circuit.py
+++ b/discopy/quantum/circuit.py
@@ -552,6 +552,19 @@ class Circuit(tensor.Diagram):
         from discopy.quantum.tk import to_tk
         return to_tk(self)
 
+    def to_pennylane(self):
+        """
+        Export DisCoPy circuit to Pennylane QNode.
+
+        Returns
+        -------
+        pennylane_circuit : discopy.quantum.pennylane.PennylaneCircuit
+        """
+
+        # pylint: disable=import-outside-toplevel
+        from discopy.quantum.pennylane import to_pennylane
+        return to_pennylane(self)
+
     @staticmethod
     def from_tk(*tk_circuits):
         """

--- a/discopy/quantum/pennylane.py
+++ b/discopy/quantum/pennylane.py
@@ -1,0 +1,175 @@
+from discopy.quantum import Circuit
+from itertools import product
+import numpy as np
+import pennylane as qml
+from pytket import OpType
+import torch
+from sympy import lambdify, Expr, Symbol
+
+
+def TK1(a, b, c, wire):
+    qml.RZ(a, wires=wire)
+    qml.RX(b, wires=wire)
+    qml.RZ(c, wires=wire)
+
+
+OP_MAP = {
+    OpType.X: qml.PauliX,
+    OpType.Y: qml.PauliY,
+    OpType.Z: qml.PauliZ,
+    OpType.S: qml.S,
+    OpType.Sdg: lambda wires: qml.S(wires=wires).inv(),
+    OpType.T: qml.T,
+    OpType.Tdg: lambda wires: qml.T(wires=wires).inv(),
+    OpType.V: lambda wires: qml.RX(1 / 2, wires=wires),
+    OpType.Vdg: lambda wires: qml.RX(-1 / 2, wires=wires),
+    OpType.SX: qml.SX,
+    OpType.SXdg: lambda wires: qml.SX(wires=wires).inv(),
+    OpType.H: qml.Hadamard,
+    OpType.Rx: qml.RX,
+    OpType.Ry: qml.RY,
+    OpType.Rz: qml.RZ,
+    OpType.U1: qml.U1,
+    OpType.U2: qml.U2,
+    OpType.U3: qml.U3,
+    OpType.TK1: TK1,
+    OpType.CX: qml.CNOT,
+    OpType.CY: qml.CY,
+    OpType.CZ: qml.CZ,
+    OpType.CH: lambda wires: qml.ctrl(qml.Hadamard(wires=wires[1]),
+                                      control=wires[0]),
+    OpType.CV: lambda wires: qml.ctrl(qml.RX(1 / 2, wires=wires[1]),
+                                      control=wires[0]),
+    OpType.CVdg: lambda wires: qml.ctrl(qml.RX(-1 / 2, wires=wires[1]),
+                                        control=wires[0]),
+    OpType.CSX: lambda wires: qml.ctrl(qml.SX(wires=wires[1]),
+                                       control=wires[0]),
+    OpType.CSXdg: lambda wires: qml.ctrl(qml.SX(wires=wires[1]).inv(),
+                                         control=wires[0]),
+    OpType.CRx: qml.CRX,
+    OpType.CRy: qml.CRY,
+    OpType.CRz: qml.CRZ,
+    OpType.CU1: lambda a, wires: qml.ctrl(qml.U1(a, wires=wires[1]),
+                                          control=wires[0]),
+    OpType.CU3: lambda a, b, c, wires: qml.ctrl(qml.U3(a, b, c,
+                                                       wires=wires[1]),
+                                                control=wires[0]),
+    OpType.CCX: qml.Toffoli,
+    OpType.SWAP: qml.SWAP,
+    OpType.CSWAP: qml.CSWAP,
+    OpType.noop: qml.Identity,
+    OpType.ISWAP: qml.ISWAP,
+    OpType.XXPhase: qml.IsingXX,
+    OpType.YYPhase: qml.IsingYY,
+    OpType.ZZPhase: qml.IsingZZ,
+}
+
+
+def tk_op_to_pennylane(tk_op):
+    wires = [x.index[0] for x in tk_op.qubits]
+    params = tk_op.op.params
+
+    return OP_MAP[tk_op.op.type], params, wires
+
+
+def get_valid_states(post_sel: dict[int, int], n_wires: int):
+    keep_indices = []
+    fixed = ['0' if post_sel.get(i, 0) == 0 else '1' for i in range(n_wires)]
+    open_wires = set(range(n_wires)) - post_sel.keys()
+    permutations = [''.join(s) for s in product('01', repeat=len(open_wires))]
+    for perm in permutations:
+        new = fixed.copy()
+        for i, open in enumerate(open_wires):
+            new[open] = perm[i]
+        keep_indices.append(int(''.join(new), 2))
+    return keep_indices
+
+
+def char_name(i):
+    num_list = [int(j) for j in str(i)]
+    chars = [chr(97 + num) for num in num_list]
+
+    return "".join(chars)
+
+
+def to_pennylane(circuit: Circuit):
+    tk_circ = circuit.to_tk()
+
+    dev = qml.device('default.qubit', wires=tk_circ.n_qubits, shots=None)
+    op_list, params_list, wires_list = [], [], []
+
+    for op in tk_circ.__iter__():
+        if op.op.type != OpType.Measure:
+            op, params, wires = tk_op_to_pennylane(op)
+            op_list.append(op)
+            params_list.append([np.pi * p for p in params])
+            wires_list.append(wires)
+
+    @qml.qnode(dev, interface="torch")
+    def circuit(circ_params: list[torch.FloatTensor]):
+        for op, params, wires in zip(op_list, circ_params, wires_list):
+            op(*params, wires=wires)
+
+        return qml.state()
+
+    def post_selected_circuit(circ_params: list[torch.FloatTensor]):
+        probs = circuit(circ_params)
+
+        post_selection = tk_circ.post_selection
+        open_wires = tk_circ.n_qubits - len(post_selection)
+        valid_states = get_valid_states(post_selection, tk_circ.n_qubits)
+
+        post_selected_probs = probs[list(valid_states)]
+
+        return torch.reshape(post_selected_probs, (2,) * open_wires)
+
+    return PennylaneCircuit(circuit, post_selected_circuit, params_list)
+
+
+class PennylaneCircuit:
+    def __init__(self, circuit: qml.QNode,
+                 post_selected_circuit: qml.QNode,
+                 params_list: list):
+        self.circuit = circuit
+        self.post_selected_circuit = post_selected_circuit
+        self.params = params_list
+
+    def draw(self):
+        param_len = sum([len(x) for x in self.params])
+        flattened_random = 2 * np.pi * torch.rand([param_len],
+                                                  requires_grad=False)
+
+        return print(qml.draw(self.circuit)(flattened_random))
+
+    def __call__(self, discopy_param_dict):
+        concrete_params = []
+
+        for expr_list in self.params:
+            conc_list = []
+            for expr in expr_list:
+                if isinstance(expr, Expr):
+
+                    # This is digusting and likely unnecessary, but it
+                    # allows us to do the correct
+                    # substitution in expression with more than
+                    # one free symbol, while using torch
+                    # tensors (this may never actually come up).
+
+                    free_symbols = list(expr.free_symbols)
+                    nice_var_mapping = {k: Symbol(char_name(v)) for k, v in
+                                        zip(free_symbols,
+                                            range(len(free_symbols)))}
+                    subs = {nice_var_mapping[s].name: discopy_param_dict[s]
+                            for s in free_symbols}
+                    lambda_expr = lambdify([nice_var_mapping[s] for s in
+                                            free_symbols],
+                                           expr.xreplace(nice_var_mapping))
+                    conc = lambda_expr(**subs)
+
+                    conc_list.append(conc)
+                else:
+                    conc_list.append(torch.tensor(expr))
+
+            concrete_params.append(conc_list)
+
+        return self.post_selected_circuit(concrete_params)

--- a/test/test_quantum.py
+++ b/test/test_quantum.py
@@ -9,6 +9,9 @@ from discopy.quantum.cqmap import *
 from discopy.quantum.circuit import *
 from discopy.quantum.gates import *
 from discopy.quantum import tk
+import pennylane as qml
+from sympy import symbols, Expr
+import torch
 
 
 def test_index2bitstring():
@@ -108,6 +111,52 @@ def test_Circuit_to_tk():
     assert repr((Bra(0) @ Bits(0) >> Bits(0) @ Id(bit)).to_tk())\
         == "tk.Circuit(1, 3).Measure(0, 1)"\
            ".post_select({1: 0}).post_process(Swap(bit, bit))"
+
+
+def test_Circuit_to_pennylane():
+    bell_state = Circuit.caps(qubit, qubit)
+    bell_effect = bell_state[::-1]
+    snake = (bell_state @ Id(1) >> Id(1) @ bell_effect)[::-1]
+    p_circ = snake.to_pennylane()
+
+    assert qml.draw(p_circ.circuit)(p_circ.params) == \
+        ("0: ───────╭C──H─┤  State\n"
+         "1: ──H─╭C─╰X────┤  State\n"
+         "2: ────╰X───────┤  State")
+
+    assert np.allclose(p_circ({}).numpy(), np.array([0.5+0j, 0+0j]))
+
+    x, y, z = symbols('x y z')
+    var_circ = Circuit(
+        dom=qubit ** 0, cod=qubit, boxes=[
+            Ket(0), Rx(0.552), Rz(x), Rx(0.917), Ket(0, 0, 0), H, H, H,
+            CRz(0.18), CRz(y), CX, H, sqrt(2), Bra(0, 0), Ket(0),
+            Rx(0.446), Rz(0.256), Rx(z), CX, H, sqrt(2), Bra(0, 0)],
+        offsets=[
+            0, 0, 0, 0, 0, 0, 1, 2, 0, 1, 2, 2,
+            3, 2, 0, 0, 0, 0, 0, 0, 1, 0])
+
+    p_var_circ = var_circ.to_pennylane()
+    var_assignment = {x: 1, y: 2, z: 3}
+    conc_params = []
+    for expr_list in p_var_circ.params:
+        conc_list = []
+        for expr in expr_list:
+            if isinstance(expr, Expr):
+                conc_list.append(float(expr.subs(var_assignment)))
+            else:
+                conc_list.append(expr)
+        conc_params.append(conc_list)
+
+    assert qml.draw(p_var_circ.circuit)(conc_params) == \
+    ('0: ──RX(2.80)──RZ(1.61)──RX(18.85)─╭C──H─┤  State\n'
+     '1: ──H────────╭C───────────────────╰X────┤  State\n'
+     '2: ──H────────╰RZ(1.13)─╭C───────────────┤  State\n'
+     '3: ──H──────────────────╰RZ(12.57)─╭C──H─┤  State\n'
+     '4: ──RX(3.47)──RZ(6.28)──RX(5.76)──╰X────┤  State')
+
+    assert np.allclose(p_var_circ(var_assignment).numpy(),
+                       np.array([0.18387039+0.08016861j, 0.18387039+0.08016861j]))
 
 
 def test_Sum_from_tk():


### PR DESCRIPTION
This PR implements a conversion from miscopy circuits to pennylane circuits, allowing them to be run on pennylane backends and take advantage if `qml` functionality.