### PR TITLE
Tk dagger

### DIFF
--- a/discopy/quantum/tk.py
+++ b/discopy/quantum/tk.py
@@ -7,7 +7,8 @@ Implements the translation between discopy and pytket.
 from unittest.mock import Mock
 
 import pytket as tk
-from pytket.circuit import Bit, Op, OpType, Qubit  # pylint: disable=no-name-in-module
+from pytket.circuit import (Bit, Op, OpType,
+                            Qubit)  # pylint: disable=no-name-in-module
 from pytket.utils import probs_from_counts
 
 from discopy import messages
@@ -34,6 +35,7 @@ OPTYPE_MAP = {"H": OpType.H,
               "CRz": OpType.CRz,
               "Swap": OpType.SWAP,
               }
+
 
 class Circuit(tk.Circuit):
     """
@@ -227,7 +229,7 @@ def to_tk(circuit):
         i_qubits = [qubits[offset + j] for j in range(len(box.dom))]
 
         if isinstance(box, (Rx, Ry, Rz)):
-            op = Op.create(OPTYPE_MAP[box.name[:2]], 2*box.phase)
+            op = Op.create(OPTYPE_MAP[box.name[:2]], 2 * box.phase)
         elif isinstance(box, Controlled):
             i_qubits = []
             idx = offset if box.distance > 0 else offset - box.distance

--- a/test/test_quantum.py
+++ b/test/test_quantum.py
@@ -154,6 +154,11 @@ def test_ClassicalGate_to_tk():
     assert Circuit.from_tk(circuit.to_tk())[-1] == post
 
 
+def test_tk_dagger():
+    assert S.dagger().to_tk() == tk.Circuit(1).Sdg(0)
+    assert T.dagger().to_tk() == tk.Circuit(1).Tdg(0)
+
+
 def test_Circuit_get_counts():
     assert Id(1).get_counts() == {(): 1.0}
 

--- a/test/test_quantum.py
+++ b/test/test_quantum.py
@@ -140,6 +140,8 @@ def test_Circuit_from_tk():
 
     m = Measure(1, destructive=False, override_bits=True)
     assert back_n_forth(m) == m.init_and_discard()
+    assert back_n_forth(CRx(0.5)) ==\
+        Ket(0) @ Ket(0) >> CRx(0.5) >> Discard() @ Discard()
     assert back_n_forth(CRz(0.5)) ==\
         Ket(0) @ Ket(0) >> CRz(0.5) >> Discard() @ Discard()
     assert Id(qubit @ bit).init_and_discard()\


### PR DESCRIPTION
Currently `to_tk()` ignores daggering of some gates including `S` and `T`. This PR fixes this behaviour.