### PR TITLE
Un-normalize pennylane

### DIFF
--- a/discopy/quantum/pennylane.py
+++ b/discopy/quantum/pennylane.py
@@ -303,9 +303,8 @@ class PennyLaneCircuit:
         open_wires = self.n_qubits - len(self._post_selection)
         post_selected_states = states[list(self._valid_states)]
 
-        if self.probs and post_selected_states.shape[0] > 1:
-            post_selected_states = \
-                post_selected_states / post_selected_states.sum().item()
+        if self.probs:
+            post_selected_states = self.scale**2 * post_selected_states
         elif not self.probs:
             post_selected_states = self.scale * post_selected_states
 

--- a/discopy/quantum/pennylane.py
+++ b/discopy/quantum/pennylane.py
@@ -200,11 +200,6 @@ class PennyLaneCircuit:
         self._post_selection = post_selection_dict
         self._valid_states = self.get_valid_states()
 
-    @property
-    def valid_states(self):
-        """The states compatible with the post-selections."""
-        return self._valid_states
-
     def contains_sympy(self):
         """
         Determine if the circuit parameters are

--- a/discopy/quantum/pennylane.py
+++ b/discopy/quantum/pennylane.py
@@ -21,7 +21,6 @@ associated weights should be passed to `eval()` as `symbols=` and
 """
 
 
-
 from discopy.quantum import Circuit
 from discopy.quantum.gates import Scalar
 from itertools import product

--- a/discopy/quantum/pennylane.py
+++ b/discopy/quantum/pennylane.py
@@ -303,11 +303,14 @@ class PennyLaneCircuit:
         open_wires = self.n_qubits - len(self._post_selection)
         post_selected_states = states[list(self._valid_states)]
 
-        if self.probs:
+        if self.probs and post_selected_states.shape[0] > 1:
             post_selected_states = \
                 post_selected_states / post_selected_states.sum().item()
-        else:
+        elif not self.probs:
             post_selected_states = self.scale * post_selected_states
+
+        if post_selected_states.shape[0] == 1:
+            return post_selected_states
 
         return torch.reshape(post_selected_states, (2,) * open_wires)
 

--- a/discopy/quantum/pennylane.py
+++ b/discopy/quantum/pennylane.py
@@ -2,12 +2,12 @@
 Implements a conversion from quantum DisCoPy circuits to
 PennyLane circuits.
 
-If `probabilities` is set to False, the ouput states of the PennyLane
+If `probabilities` is set to False, the output states of the PennyLane
 circuit will be exactly equivalent to those of the DisCoPy circuit
 (for the same parameters).
 
 If `probabilities` is set to True, the output states of the PennyLane
-circuit will be the probabilities of the ouput states, equivalent
+circuit will be the probabilities of the output states, equivalent
 to appending :class:`discopy.quantum.circuit.Measure` to all the
 open wires in the DisCoPy circuit.
 

--- a/discopy/quantum/pennylane.py
+++ b/discopy/quantum/pennylane.py
@@ -123,7 +123,8 @@ def get_post_selection_dict(tk_circ):
     """
     q_post_sels = {}
     for q, c in tk_circ.qubit_to_bit_map.items():
-        q_post_sels[q.index[0]] = tk_circ.post_selection[c.index[0]]
+        if c.index[0] in tk_circ.post_selection.keys():
+            q_post_sels[q.index[0]] = tk_circ.post_selection[c.index[0]]
     return q_post_sels
 
 

--- a/test/test_quantum.py
+++ b/test/test_quantum.py
@@ -147,7 +147,8 @@ def test_Circuit_to_pennylane(capsys):
     # probabilities should not be normalized if all wires are post-selected
     p_no_open_snake_prob = no_open_snake.to_pennylane(probabilities=True)
 
-    assert np.allclose(p_no_open_snake_prob.eval().numpy(), no_open_snake.eval().array)
+    assert np.allclose(p_no_open_snake_prob.eval().numpy(),
+                       no_open_snake.eval().array)
 
     x, y, z = sympy.symbols('x y z')
     symbols = [x, y, z]

--- a/test/test_quantum.py
+++ b/test/test_quantum.py
@@ -115,8 +115,8 @@ def test_Circuit_to_pennylane(capsys):
     bell_state = Circuit.caps(qubit, qubit)
     bell_effect = bell_state[::-1]
     snake = (bell_state @ Id(1) >> Bra(0) @ bell_effect)[::-1]
-    p_circ = snake.to_pennylane()
-    p_circ.draw()
+    p_snake = snake.to_pennylane()
+    p_snake.draw()
 
     captured = capsys.readouterr()
     assert captured.out == \
@@ -124,13 +124,30 @@ def test_Circuit_to_pennylane(capsys):
          "1: ──H─╭●─╰X────┤0>\n"
          "2: ────╰X───────┤  State\n")
 
-    assert np.allclose(p_circ.eval().numpy(), snake.eval().array)
+    assert np.allclose(p_snake.eval().numpy(), snake.eval().array)
 
-    p_circ_prob = snake.to_pennylane(probabilities=True)
-    circ_prob = np.square(np.abs(snake.eval().array))
-    circ_prob = circ_prob / np.sum(circ_prob)
+    p_snake_prob = snake.to_pennylane(probabilities=True)
+    snake_prob = np.square(np.abs(snake.eval().array))
+    snake_prob = snake_prob / np.sum(snake_prob)
 
-    assert(np.allclose(p_circ_prob.eval().numpy(), circ_prob))
+    assert(np.allclose(p_snake_prob.eval().numpy(), snake_prob))
+
+    no_open_snake = (bell_state @ Ket(0) >> Bra(0) @ bell_effect)[::-1]
+    p_no_open_snake = no_open_snake.to_pennylane()
+    p_no_open_snake.draw()
+
+    captured = capsys.readouterr()
+    assert captured.out == \
+        ("0: ───────╭●──H─┤0>\n"
+         "1: ──H─╭●─╰X────┤0>\n"
+         "2: ────╰X───────┤0>\n")
+
+    assert np.allclose(p_no_open_snake.eval().numpy(), no_open_snake.eval().array)
+
+    # probabilities should not be normalized if all wires are post-selected
+    p_no_open_snake_prob = no_open_snake.to_pennylane(probabilities=True)
+
+    assert np.allclose(p_no_open_snake_prob.eval().numpy(), np.array([0.25]))
 
     x, y, z = sympy.symbols('x y z')
     symbols = [x, y, z]
@@ -173,7 +190,7 @@ def test_Circuit_to_pennylane(capsys):
 def test_PennylaneCircuit_draw(capsys):
     bell_state = Circuit.caps(qubit, qubit)
     bell_effect = bell_state[::-1]
-    snake = (bell_state @ Id(1) >> Id(1) @ bell_effect)[::-1]
+    snake = (bell_state @ Id(1) >> Bra(0) @ bell_effect)[::-1]
     p_circ = snake.to_pennylane()
     p_circ.draw()
 

--- a/test/test_quantum.py
+++ b/test/test_quantum.py
@@ -142,7 +142,8 @@ def test_Circuit_to_pennylane(capsys):
          "1: ──H─╭●─╰X────┤0>\n"
          "2: ────╰X───────┤0>\n")
 
-    assert np.allclose(p_no_open_snake.eval().numpy(), no_open_snake.eval().array)
+    assert np.allclose(p_no_open_snake.eval().numpy(),
+                       no_open_snake.eval().array)
 
     # probabilities should not be normalized if all wires are post-selected
     p_no_open_snake_prob = no_open_snake.to_pennylane(probabilities=True)

--- a/test/test_quantum.py
+++ b/test/test_quantum.py
@@ -127,10 +127,9 @@ def test_Circuit_to_pennylane(capsys):
     assert np.allclose(p_snake.eval().numpy(), snake.eval().array)
 
     p_snake_prob = snake.to_pennylane(probabilities=True)
-    snake_prob = np.square(np.abs(snake.eval().array))
-    snake_prob = snake_prob / np.sum(snake_prob)
+    snake_prob = (snake >> Measure())
 
-    assert(np.allclose(p_snake_prob.eval().numpy(), snake_prob))
+    assert(np.allclose(p_snake_prob.eval().numpy(), snake_prob.eval().array))
 
     no_open_snake = (bell_state @ Ket(0) >> Bra(0) @ bell_effect)[::-1]
     p_no_open_snake = no_open_snake.to_pennylane()
@@ -148,7 +147,7 @@ def test_Circuit_to_pennylane(capsys):
     # probabilities should not be normalized if all wires are post-selected
     p_no_open_snake_prob = no_open_snake.to_pennylane(probabilities=True)
 
-    assert np.allclose(p_no_open_snake_prob.eval().numpy(), np.array([0.25]))
+    assert np.allclose(p_no_open_snake_prob.eval().numpy(), no_open_snake.eval().array)
 
     x, y, z = sympy.symbols('x y z')
     symbols = [x, y, z]
@@ -181,11 +180,10 @@ def test_Circuit_to_pennylane(capsys):
                        conc_circ.eval().array)
 
     p_var_circ_prob = var_circ.to_pennylane(probabilities=True)
-    var_circ_prob = np.square(np.abs(conc_circ.eval().array))
-    var_circ_prob = var_circ_prob / np.sum(var_circ_prob)
+    conc_circ_prob = (conc_circ >> Measure())
 
     assert(np.allclose(p_var_circ_prob.eval(symbols, weights).numpy(),
-                       var_circ_prob))
+                       conc_circ_prob.eval().array))
 
 
 def test_PennylaneCircuit_draw(capsys):

--- a/test/test_quantum.py
+++ b/test/test_quantum.py
@@ -187,6 +187,15 @@ def test_Circuit_to_pennylane(capsys):
                        conc_circ_prob.eval().array))
 
 
+def test_PennyLaneCircuit_mixed_error():
+    bell_state = Circuit.caps(qubit, qubit)
+    bell_effect = bell_state[::-1]
+    snake = (bell_state @ Id(1) >> Bra(0) @ bell_effect)[::-1]
+    snake = (snake >> Measure())
+    with raises(ValueError):
+        snake.to_pennylane()
+
+
 def test_PennylaneCircuit_draw(capsys):
     bell_state = Circuit.caps(qubit, qubit)
     bell_effect = bell_state[::-1]

--- a/test/test_quantum.py
+++ b/test/test_quantum.py
@@ -212,12 +212,12 @@ def test_pennylane_update_post_selection():
     p_circ = snake.to_pennylane()
 
     assert p_circ.post_selection == {0: 0, 1: 0}
-    assert p_circ.valid_states == [0, 1]
+    assert p_circ._valid_states == [0, 1]
 
     p_circ.post_selection = {0: 0, 2: 0}
 
     assert p_circ.post_selection == {0: 0, 2: 0}
-    assert p_circ.valid_states == [0, 2]
+    assert p_circ._valid_states == [0, 2]
 
 
 def test_Sum_from_tk():


### PR DESCRIPTION
Don't normalise the probability output. Now consistent with DisCoPy `Measure()`.