### PR TITLE
QoL improvement: show the conflicting types in a composition error.

### DIFF
--- a/discopy/biclosed.py
+++ b/discopy/biclosed.py
@@ -225,7 +225,7 @@ class FC(BinaryBoxConstructor, Box):
         if not isinstance(right, Over):
             raise TypeError(messages.type_err(Over, right))
         if left.right != right.left:
-            raise TypeError(messages.does_not_compose(left, right))
+            raise TypeError(messages.types_do_not_compose(left, right))
         name = "FC({}, {})".format(left, right)
         dom, cod = left @ right, left.left << right.right
         Box.__init__(self, name, dom, cod)
@@ -240,7 +240,7 @@ class BC(BinaryBoxConstructor, Box):
         if not isinstance(right, Under):
             raise TypeError(messages.type_err(Under, right))
         if left.right != right.left:
-            raise TypeError(messages.does_not_compose(left, right))
+            raise TypeError(messages.types_do_not_compose(left, right))
         name = "BC({}, {})".format(left, right)
         dom, cod = left @ right, left.left >> right.right
         Box.__init__(self, name, dom, cod)
@@ -255,7 +255,7 @@ class FX(BinaryBoxConstructor, Box):
         if not isinstance(right, Under):
             raise TypeError(messages.type_err(Over, right))
         if left.right != right.right:
-            raise TypeError(messages.does_not_compose(left, right))
+            raise TypeError(messages.types_do_not_compose(left, right))
         name = "FX({}, {})".format(left, right)
         dom, cod = left @ right, right.left >> left.left
         Box.__init__(self, name, dom, cod)
@@ -270,7 +270,7 @@ class BX(BinaryBoxConstructor, Box):
         if not isinstance(right, Under):
             raise TypeError(messages.type_err(Under, right))
         if left.left != right.left:
-            raise TypeError(messages.does_not_compose(left, right))
+            raise TypeError(messages.types_do_not_compose(left, right))
         name = "BX({}, {})".format(left, right)
         dom, cod = left @ right, right.right << left.right
         Box.__init__(self, name, dom, cod)

--- a/discopy/messages.py
+++ b/discopy/messages.py
@@ -12,6 +12,11 @@ def type_err(expected, got):
         repr(got), type(got).__module__, type(got).__name__)
 
 
+def types_do_not_compose(left, right):
+    """ Composition error. """
+    return "{} does not compose with {}.".format(left, right)
+
+
 def does_not_compose(left, right):
     """ Composition error. """
     return "{} does not compose with {}: cod={}, dom={}.".format(

--- a/discopy/messages.py
+++ b/discopy/messages.py
@@ -14,7 +14,8 @@ def type_err(expected, got):
 
 def does_not_compose(left, right):
     """ Composition error. """
-    return "{} does not compose with {}.".format(left, right)
+    return "{} does not compose with {}: cod={}, dom={}.".format(
+        left, right, left.cod, right.dom)
 
 
 def is_not_connected(diagram):


### PR DESCRIPTION
Since this is a very common case in practice, it would be good to see what the conflict is, so it is easier to diagnose the issue from the error message.