### PR TITLE
Defer slow imports of matplotlib, networkx and sympy.

### DIFF
--- a/discopy/drawing.py
+++ b/discopy/drawing.py
@@ -1,17 +1,19 @@
 # -*- coding: utf-8 -*-
 """ Drawing module. """
 
-import os
-from dataclasses import dataclass
 from abc import ABC, abstractmethod
+from math import sqrt
+import os
 from tempfile import NamedTemporaryFile, TemporaryDirectory
 
-import networkx as nx
 from PIL import Image
-import matplotlib.pyplot as plt
-from matplotlib.path import Path
-from matplotlib.patches import PathPatch
-from math import sqrt
+
+
+def _import_matplotlib():
+    global plt, Path, PathPatch
+    import matplotlib.pyplot as plt
+    from matplotlib.path import Path
+    from matplotlib.patches import PathPatch
 
 
 # Mapping from attribute to function from box to default value.
@@ -100,6 +102,7 @@ def diagram2nx(diagram):
     positions : Mapping[Node, Tuple[float, float]]
         from nodes to pairs of floats.
     """
+    import networkx as nx
     diagram = add_drawing_attributes(diagram.open_bubbles())
     graph, pos = nx.DiGraph(), dict()
 
@@ -289,6 +292,7 @@ class Backend(ABC):
         if spider_widths:
             self.max_width = max(self.max_width, max(spider_widths))
 
+    @abstractmethod
     def output(self, path=None, show=True, **params):
         """ Output the drawing. """
 
@@ -441,6 +445,8 @@ class TikzBackend(Backend):
 class MatBackend(Backend):
     """ Matplotlib drawing backend. """
     def __init__(self, axis=None, figsize=None):
+        _import_matplotlib()
+
         self.axis = axis or plt.subplots(figsize=figsize, facecolor='white')[1]
         super().__init__()
 
@@ -480,6 +486,7 @@ class MatBackend(Backend):
         super().draw_wire(source, target, bend_out=bend_out, bend_in=bend_in)
 
     def draw_spiders(self, graph, positions, draw_box_labels=True, **params):
+        import networkx as nx
         nodes = {node for node in graph.nodes
                  if node.kind == "box" and node.box.draw_as_spider}
         shapes = {node: node.box.shape for node in nodes}
@@ -976,6 +983,7 @@ def diagramize(dom, cod, boxes, id_factory=None):
     id_factory = id_factory or boxes[0].id
 
     def decorator(func):
+        import networkx as nx
         from discopy import messages
         from discopy.cat import AxiomError
         from discopy.cartesian import tuplify, untuplify

--- a/discopy/quantum/optics.py
+++ b/discopy/quantum/optics.py
@@ -32,18 +32,16 @@ Example
     :align: center
 """
 
-import numpy as np
-from math import factorial, pi
 from itertools import permutations
+from math import factorial
 
-import sympy
+import numpy as np
 
 from discopy import cat, messages, monoidal
-from discopy.monoidal import PRO
-
 from discopy.matrix import Matrix
-from discopy.rewriting import InterchangerError
+from discopy.monoidal import PRO
 from discopy.quantum.gates import format_number
+from discopy.rewriting import InterchangerError
 
 
 def occupation_numbers(n_photons, m_modes):
@@ -600,6 +598,7 @@ class Phase(Box):
 
     @property
     def matrix(self):
+        import sympy
         backend = sympy if hasattr(self.phi, 'free_symbols') else np
         array = backend.exp(1j * 2 * backend.pi * self.phi)
         return Matrix(self.dom, self.cod, array)
@@ -754,6 +753,7 @@ class MZI(Box):
 
     @property
     def matrix(self):
+        import sympy
         backend = sympy if hasattr(self.theta, 'free_symbols') else np
         cos = backend.cos(backend.pi * self.theta)
         sin = backend.sin(backend.pi * self.theta)
@@ -838,6 +838,7 @@ def to_matrix(diagram):
 
 def ar_optics2path(box):
     if isinstance(box, Phase):
+        import sympy
         backend = sympy if hasattr(box.phi, 'free_symbols') else np
         return Endo(backend.exp(2j * backend.pi * box.phi))
     if isinstance(box, TBS):


### PR DESCRIPTION
Old:
```bash
(venv)  > time python -c 'import discopy'
python -c 'import discopy'  1.50s user 0.24s system 138% cpu 1.251 total
(venv)  > time python -c 'import discopy'
python -c 'import discopy'  1.49s user 0.24s system 138% cpu 1.242 total
(venv)  > time python -c 'import discopy'
python -c 'import discopy'  1.49s user 0.24s system 138% cpu 1.253 total
```

New:
```bash
(venv)  > time python -c 'import discopy'
python -c 'import discopy'  0.42s user 0.12s system 239% cpu 0.223 total
(venv)  > time python -c 'import discopy'
python -c 'import discopy'  0.38s user 0.11s system 243% cpu 0.204 total
(venv)  > time python -c 'import discopy'
python -c 'import discopy'  0.38s user 0.11s system 241% cpu 0.203 total
```

Average 1.25 / 0.21 ≈ 6x speed-up