### PR TITLE
Add l,r - adjoints to Swap

### DIFF
--- a/discopy/rigid.py
+++ b/discopy/rigid.py
@@ -454,6 +454,14 @@ class Swap(monoidal.Swap, Box):
         monoidal.Swap.__init__(self, left, right)
         Box.__init__(self, self.name, self.dom, self.cod)
 
+    @property
+    def l(self):
+        return Swap(self.right.l, self.left.l)
+
+    @property
+    def r(self):
+        return Swap(self.right.r, self.left.r)
+
 
 class Cup(monoidal.BinaryBoxConstructor, Box):
     """ Defines cups for simple types.

--- a/test/test_rigid.py
+++ b/test/test_rigid.py
@@ -173,6 +173,8 @@ def test_adjoint():
     diagram = Bob @ eats >> Cup(n, n.r) @ Id(s)
     assert diagram.l == Bob_l >> eats_l @ Id(n.l) >> Id(s.l) @ Cup(n, n.l)
     assert diagram.r == Bob_r >> eats_r @ Id(n.r) >> Id(s.r) @ Cup(n.r.r, n.r)
+    assert (eats >> Swap(n.r, s)).l == eats_l >> Swap(s.l, n)
+    assert (eats >> Swap(n.r, s)).r == eats_r >> Swap(s.r, n.r.r)
 
 
 def test_id_adjoint():


### PR DESCRIPTION
Currently, taking the adjoint of a diagram with a swap yields the error:

```
File ~/nkqnlp/lib/python3.8/site-packages/discopy/rigid.py:159, in Layer.r(self)
    157 @property
    158 def r(self):
--> 159     return Layer(self._right.r, self._box.r, self._left.r)

File ~/nkqnlp/lib/python3.8/site-packages/discopy/rigid.py:446, in Box.r(self)
    444 @property
    445 def r(self):
--> 446     return type(self)(
    447         name=self.name, dom=self.dom.r, cod=self.cod.r,
    448         data=self.data, _dagger=self._dagger, _z=self._z + 1)

TypeError: __init__() got an unexpected keyword argument 'name'
```

This change fixes this bug.