### PR TITLE
Add support for Ry gate in from_tk

### DIFF
--- a/discopy/quantum/tk.py
+++ b/discopy/quantum/tk.py
@@ -316,6 +316,8 @@ def from_tk(tk_circuit):
         name = tk_gate.op.type.name
         if name == 'Rx':
             return Rx(tk_gate.op.params[0] / 2)
+        if name == 'Ry':
+            return Ry(tk_gate.op.params[0] / 2)
         if name == 'Rz':
             return Rz(tk_gate.op.params[0] / 2)
         if name == 'CRx':

--- a/test/test_quantum.py
+++ b/test/test_quantum.py
@@ -287,6 +287,9 @@ def test_Circuit_from_tk():
         == back_n_forth(Swap(qubit, bit)) == back_n_forth(Swap(bit, qubit))
     c = (T >> T.dagger()).init_and_discard()
     assert c == back_n_forth(c)
+    symbs_xyz = (sympy.Symbol('x'), sympy.Symbol('y'), sympy.Symbol('z'))
+    circ_xyz = Rx(symbs_xyz[0]) >> Ry(symbs_xyz[1]) >> Rz(symbs_xyz[2])
+    assert back_n_forth(circ_xyz) == circ_xyz.init_and_discard()
 
 
 def test_ClassicalGate_to_tk():


### PR DESCRIPTION
Currently calling `to_tk` on a circuit with an `Ry` gate yields a `NotImplementedError`.
This change fixes this.